### PR TITLE
Update readme and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Generated images
+debug_board_detection.png
+last_board.png
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can run it from source code with Python, or execute the compiled binary.
 
 ## Requirements if run from source code.
 - Dota 2 with FullHD resolution: 1920x1080
-- Python 3.11+ (https://www.python.org/downloads/)
+- Python 3.12 **(3.13 not supported by scikit-image)** (https://www.python.org/downloads/)
 - Pip (https://pip.pypa.io/en/stable/installation/)
 
 ## How to install from .exe


### PR DESCRIPTION
Found out that Python 3.13 is not supported by scikit-image (trying to install it gives a bunch of different errors). Updated the readme to explicitly mention it and also added the auto generated images to the gitignore file.